### PR TITLE
Fix for "shl": copy leftmost bit to bit 0.

### DIFF
--- a/R200 emulator/src/Remulator.cs
+++ b/R200 emulator/src/Remulator.cs
@@ -238,7 +238,7 @@ namespace remu
                 case "shcr": state.setGPRupdFlags(dest, ((r1&1) << dataBusWidth) | (Convert.ToUInt32(state.c) << (dataBusWidth-1)) | (r1>>1), State.Zmode.AND); break;
                 case "shr": state.setGPRupdFlags(dest, r1>>1, State.Zmode.SKIP); break;
                 case "shcl": state.setGPRupdFlags(dest, Convert.ToUInt32(state.c) | (r1 << 1), State.Zmode.AND); break;
-                case "shl": state.setGPRupdFlags(dest, (r1 << 1) & dataBusMask, State.Zmode.SKIP); break;
+                case "shl": state.setGPRupdFlags(dest, (r1 << 1) & dataBusMask | (((1 << dataBusWidth - 1) & r1) >> dataBusWidth - 1), State.Zmode.SKIP); break;
                 case "not": state.setGPRupdFlags(dest, ((r1 << 1) & ~dataBusMask) | (~r1 & dataBusMask), State.Zmode.UPD); break;
                 case "and": state.setGPRupdFlags(dest, (1 << dataBusWidth) | (r1 & r2), State.Zmode.UPD); break;
                 case "or": state.setGPRupdFlags(dest, (r1 | r2), State.Zmode.UPD); break;

--- a/R200 emulator/src/Remulator.cs
+++ b/R200 emulator/src/Remulator.cs
@@ -236,9 +236,9 @@ namespace remu
                 case "inc": state.setGPRupdFlags(dest, r1 + 1, State.Zmode.UPD); break;
                 case "dec": state.setGPRupdFlags(dest, r1 - 1, State.Zmode.UPD); break;
                 case "shcr": state.setGPRupdFlags(dest, ((r1&1) << dataBusWidth) | (Convert.ToUInt32(state.c) << (dataBusWidth-1)) | (r1>>1), State.Zmode.AND); break;
-                case "shr": state.setGPRupdFlags(dest, r1>>1, State.Zmode.SKIP); break;
+                case "shr": state.setGPRupdFlags(dest, (r1 >> 1) | (r1 << dataBusWidth - 1), State.Zmode.SKIP); break;
                 case "shcl": state.setGPRupdFlags(dest, Convert.ToUInt32(state.c) | (r1 << 1), State.Zmode.AND); break;
-                case "shl": state.setGPRupdFlags(dest, (r1 << 1) & dataBusMask | (((1 << dataBusWidth - 1) & r1) >> dataBusWidth - 1), State.Zmode.SKIP); break;
+                case "shl": state.setGPRupdFlags(dest, ((r1 << 1) & dataBusMask) | (r1 >> dataBusWidth - 1), State.Zmode.SKIP); break;
                 case "not": state.setGPRupdFlags(dest, ((r1 << 1) & ~dataBusMask) | (~r1 & dataBusMask), State.Zmode.UPD); break;
                 case "and": state.setGPRupdFlags(dest, (1 << dataBusWidth) | (r1 & r2), State.Zmode.UPD); break;
                 case "or": state.setGPRupdFlags(dest, (r1 | r2), State.Zmode.UPD); break;


### PR DESCRIPTION
Possibly I'm mistaken, but according to documentation, SHL command should do kind of rotation:
Shift circular left | Rd ← (Rd<<1):Rd_{N-1}

However, only simple shift was performed.